### PR TITLE
Remove pseudo selector :scope in querySelector.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,7 @@
 "use strict";
 
 let preloader = document.querySelector('.preloader');
-let preloaderText = preloader.querySelector(':scope .preloader__text');
+let preloaderText = preloader.querySelector('.preloader__text');
 let the_physics = new Physics();
 let the_longcat = new LongCat(document.querySelector('.longcat'), the_physics);
 let sections = setupSections();


### PR DESCRIPTION
Which is not supported by edge.

see also:
https://developer.mozilla.org/en-US/docs/Web/CSS/%3Ascope#Browser_compatibility
